### PR TITLE
Adds support for requests with form data

### DIFF
--- a/flask_bind/decorators.py
+++ b/flask_bind/decorators.py
@@ -31,7 +31,14 @@ def route(app: Union[Blueprint, Flask], path: str, **kwargs):
         @app.route(path, **kwargs)
         @wraps(fn)
         def inner(*args, **kw):
-            data = request.get_json()
+            content_type = request.headers.get("content-type")
+            try:
+                data = {
+                    "application/json": request.get_json,
+                    "application/x-www-form-urlencoded": lambda: request.form,
+                }[content_type]()
+            except KeyError:
+                return fn(*args, **kw)
 
             model_map: Dict[str, MaybeModel] = {
                 arg: maybe_model

--- a/test/test_app/app.py
+++ b/test/test_app/app.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from flask import Flask, make_response
 from flask_bind.decorators import route
-from pydantic import ValidationError
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from .models import Model, Node, NodePatch
 from .utils import extend
@@ -80,3 +80,13 @@ def put_node(node_id, node: Node):
 @route(app, "/node/<int:node_id>", methods=["PATCH"])
 def patch_node(node_id, node: NodePatch):
     return "", HTTPStatus.NO_CONTENT
+
+
+class Form(BaseModel):
+    username: str
+    password: SecretStr
+
+
+@route(app, "/form", methods=["POST"])
+def post_form(form: Form):
+    return {"username": form.username}

--- a/test/test_route.py
+++ b/test/test_route.py
@@ -86,3 +86,11 @@ def test_patch_model(client):
 
     response = client.patch("/node/1", json={})
     assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_form_data(client):
+    response = client.post(
+        "/form",
+        data={"username": "user@domain.com", "password": "correcthorsebatterystaple"},
+    )
+    assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
This PR addresses #2. It handles data sourcing based on the request content type.

In doing so, we're adding support for data submitted via `application/x-www-form-urlencoded`.

